### PR TITLE
feat(db): redesign booking schema and lock seats to prevent double-booking

### DIFF
--- a/src/main/java/com/cinebee/entity/Seat.java
+++ b/src/main/java/com/cinebee/entity/Seat.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Entity
-@Table(name = "Seats", uniqueConstraints = @UniqueConstraint(columnNames = { "showtime_id", "seat_number" }))
+@Table(name = "Seats", uniqueConstraints = @UniqueConstraint(columnNames = {"showtime_id", "seat_number"}))
 @Getter
 @Setter
 public class Seat {
@@ -24,6 +24,13 @@ public class Seat {
     @Column(nullable = false)
     private RoomSeat.SeatType seatType = RoomSeat.SeatType.STANDARD;
 
+    @Column(nullable = false)
     private Boolean isAvailable = true;
-    private Double priceModifier;
+
+    @Column(nullable = false)
+    private Double priceModifier = 1.0;
+
+    @Version
+    @Column(nullable = false)
+    private Long version = 0L;
 }

--- a/src/main/java/com/cinebee/entity/Ticket.java
+++ b/src/main/java/com/cinebee/entity/Ticket.java
@@ -9,7 +9,13 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "Tickets")
+@Table(
+        name = "Tickets",
+        indexes = {
+                @Index(name = "idx_tickets_showtime_cancelled", columnList = "showtime_id, is_cancelled"),
+                @Index(name = "idx_tickets_booking_reference", columnList = "booking_reference")
+        }
+)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -33,11 +39,14 @@ public class Ticket {
     @Column(nullable = false)
     private Double price;
 
+    @Column(name = "booking_reference", nullable = false, length = 64)
+    private String bookingReference;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime bookedAt;
 
-    @Column(nullable = false)
+    @Column(name = "is_cancelled", nullable = false)
     private Boolean isCancelled = false;
 
     @Column(name = "cancelled_at")
@@ -45,8 +54,7 @@ public class Ticket {
 
     @Column
     private Integer ticketSales = 0;
-    
-    // Getter method for total price (same as price for single ticket)
+
     public Double getTotalPrice() {
         return this.price;
     }

--- a/src/main/java/com/cinebee/repository/SeatRepository.java
+++ b/src/main/java/com/cinebee/repository/SeatRepository.java
@@ -2,26 +2,28 @@ package com.cinebee.repository;
 
 import com.cinebee.entity.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
-    /**
-     * Find all seats for a given showtime.
-     * @param showtimeId The ID of the showtime.
-     * @return A list of seats.
-     */
     List<Seat> findByShowtimeId(Long showtimeId);
 
-    /**
-     * Find a specific seat by its number within a given showtime.
-     * @param showtimeId The ID of the showtime.
-     * @param seatNumber The number of the seat (e.g., "A1").
-     * @return An Optional containing the seat if found.
-     */
+    List<Seat> findByShowtimeIdAndIsAvailableTrue(Long showtimeId);
+
     Optional<Seat> findByShowtimeIdAndSeatNumber(Long showtimeId, String seatNumber);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM Seat s WHERE s.showtime.id = :showtimeId AND s.seatNumber IN :seatNumbers")
+    List<Seat> findByShowtimeIdAndSeatNumberInForUpdate(
+            @Param("showtimeId") Long showtimeId,
+            @Param("seatNumbers") List<String> seatNumbers
+    );
 }

--- a/src/main/java/com/cinebee/repository/TicketRepository.java
+++ b/src/main/java/com/cinebee/repository/TicketRepository.java
@@ -10,20 +10,19 @@ import java.util.List;
 
 @Repository
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
-    
-    // Find booked seats for a specific showtime
+
     @Query("SELECT s.seatNumber FROM Ticket t JOIN t.seat s WHERE t.showtime.id = :showtimeId AND t.isCancelled = false")
     List<String> findBookedSeatsByShowtime(@Param("showtimeId") Long showtimeId);
-    
-    // Find tickets by user
+
     List<Ticket> findByUserId(Long userId);
-    
-    // Find tickets by showtime
+
     List<Ticket> findByShowtimeId(Long showtimeId);
-    
-    // Find tickets by user and showtime
+
     List<Ticket> findByUserIdAndShowtimeId(Long userId, Long showtimeId);
-    
-    // Count tickets for a showtime
+
+    List<Ticket> findByBookingReference(String bookingReference);
+
+    boolean existsByShowtimeIdAndSeatIdAndIsCancelledFalse(Long showtimeId, Long seatId);
+
     long countByShowtimeId(Long showtimeId);
 }

--- a/src/main/java/com/cinebee/service/impl/TicketServiceImpl.java
+++ b/src/main/java/com/cinebee/service/impl/TicketServiceImpl.java
@@ -2,10 +2,12 @@ package com.cinebee.service.impl;
 
 import com.cinebee.dto.request.BookingRequest;
 import com.cinebee.dto.response.BookingResponse;
-import com.cinebee.entity.*;
+import com.cinebee.entity.Seat;
+import com.cinebee.entity.Showtime;
+import com.cinebee.entity.Ticket;
+import com.cinebee.entity.User;
 import com.cinebee.exception.ApiException;
 import com.cinebee.exception.ErrorCode;
-import com.cinebee.repository.*;
 import com.cinebee.repository.SeatRepository;
 import com.cinebee.repository.ShowtimeRepository;
 import com.cinebee.repository.TicketRepository;
@@ -17,10 +19,14 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,17 +38,16 @@ public class TicketServiceImpl implements TicketService {
     private final UserRepository userRepository;
     private final ShowtimeRepository showtimeRepository;
     private final SeatRepository seatRepository;
-    // PaymentRepository is not used in this logic, can be removed if not needed elsewhere
 
     @Override
     @Transactional
     public BookingResponse createBooking(BookingRequest request) {
-        // 1. Get current user
         String currentUsername = SecurityContextHolder.getContext().getAuthentication().getName();
         User currentUser = userRepository.findByUsername(currentUsername)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found: " + currentUsername));
 
-        // 2. Get Showtime
+        validateBookingRequest(request);
+
         Showtime showtime = showtimeRepository.findById(request.getShowtimeId())
                 .orElseThrow(() -> new ApiException(ErrorCode.SHOWTIME_NOT_FOUND));
 
@@ -50,44 +55,58 @@ public class TicketServiceImpl implements TicketService {
             throw new ApiException(ErrorCode.SHOWTIME_HAS_PASSED);
         }
 
-        List<Ticket> createdTickets = new ArrayList<>();
-        List<Seat> seatsToUpdate = new ArrayList<>();
-        double totalPrice = 0.0;
+        Set<String> normalizedSeatNumbers = request.getSeatNumbers().stream()
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        // 3. Process each selected seat
-        for (String seatNumber : request.getSeatNumbers()) {
-            Seat seat = seatRepository.findByShowtimeIdAndSeatNumber(showtime.getId(), seatNumber)
-                    .orElseThrow(() -> new ApiException(ErrorCode.SEAT_NOT_FOUND, "Seat " + seatNumber + " not found for this showtime."));
+        List<String> selectedSeatNumbers = new ArrayList<>(normalizedSeatNumbers);
 
-            if (!seat.getIsAvailable()) {
-                throw new ApiException(ErrorCode.SEAT_NOT_AVAILABLE, "Seat " + seatNumber + " is already booked.");
+        // Lock selected seats in DB to prevent race condition when two users book same seats concurrently.
+        List<Seat> lockedSeats = seatRepository.findByShowtimeIdAndSeatNumberInForUpdate(
+                showtime.getId(),
+                selectedSeatNumbers
+        );
+
+        if (lockedSeats.size() != selectedSeatNumbers.size()) {
+            throw new ApiException(ErrorCode.SEAT_NOT_FOUND, "One or more selected seats do not exist for this showtime.");
+        }
+
+        for (Seat seat : lockedSeats) {
+            if (!Boolean.TRUE.equals(seat.getIsAvailable())) {
+                throw new ApiException(
+                        ErrorCode.SEAT_NOT_AVAILABLE,
+                        "Seat " + seat.getSeatNumber() + " is already booked."
+                );
             }
+        }
 
-            // 4. Mark seat as unavailable and create a ticket
+        List<Ticket> createdTickets = new ArrayList<>();
+        double totalPrice = 0.0;
+        String bookingReference = UUID.randomUUID().toString();
+
+        for (Seat seat : lockedSeats) {
             seat.setIsAvailable(false);
-            seatsToUpdate.add(seat);
 
             Ticket ticket = new Ticket();
             ticket.setUser(currentUser);
             ticket.setShowtime(showtime);
             ticket.setSeat(seat);
-            
-            // Calculate price for this specific ticket
+            ticket.setBookingReference(bookingReference);
+
             Double ticketPrice = showtime.getMovie().getBasePrice() * seat.getPriceModifier();
             ticket.setPrice(ticketPrice);
             totalPrice += ticketPrice;
-            
+
             createdTickets.add(ticket);
         }
 
-        // 5. Save all changes to the database
-        seatRepository.saveAll(seatsToUpdate);
+        seatRepository.saveAll(lockedSeats);
         List<Ticket> savedTickets = ticketRepository.saveAll(createdTickets);
 
-        log.info("Successfully created {} tickets for user {}", savedTickets.size(), currentUsername);
+        log.info("Successfully created {} tickets for user {} with bookingReference {}",
+                savedTickets.size(), currentUsername, bookingReference);
 
-        // 6. Create and return the response from the first saved ticket
-        // (Assuming a booking can be represented by its first ticket)
         return mapToBookingResponse(savedTickets.get(0), savedTickets, totalPrice);
     }
 
@@ -97,11 +116,10 @@ public class TicketServiceImpl implements TicketService {
         if (!showtimeRepository.existsById(showtimeId)) {
             throw new ApiException(ErrorCode.SHOWTIME_NOT_FOUND);
         }
-        
-        List<Seat> allSeats = seatRepository.findByShowtimeId(showtimeId);
-        
+
+        List<Seat> allSeats = seatRepository.findByShowtimeIdAndIsAvailableTrue(showtimeId);
+
         return allSeats.stream()
-                .filter(Seat::getIsAvailable)
                 .map(seat -> {
                     Double finalPrice = seat.getShowtime().getMovie().getBasePrice() * seat.getPriceModifier();
                     return new BookingResponse.SeatInfo(seat.getSeatNumber(), seat.getSeatType().name(), finalPrice);
@@ -109,17 +127,26 @@ public class TicketServiceImpl implements TicketService {
                 .collect(Collectors.toList());
     }
 
-    // Helper method to map to response
+    private void validateBookingRequest(BookingRequest request) {
+        if (request == null || request.getShowtimeId() == null) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "Showtime is required.");
+        }
+
+        if (CollectionUtils.isEmpty(request.getSeatNumbers())) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "Seat list must not be empty.");
+        }
+    }
+
     private BookingResponse mapToBookingResponse(Ticket representativeTicket, List<Ticket> allTickets, double totalPrice) {
         BookingResponse response = new BookingResponse();
-        response.setTicketId(representativeTicket.getId()); // Use the ID of the first ticket as the representative booking ID
+        response.setTicketId(representativeTicket.getId());
         response.setShowtimeId(representativeTicket.getShowtime().getId());
         response.setMovieTitle(representativeTicket.getShowtime().getMovie().getTitle());
         response.setTheaterName(representativeTicket.getShowtime().getTheater().getName());
         response.setRoomName(representativeTicket.getShowtime().getRoom().getName());
         response.setShowtime(representativeTicket.getShowtime().getStartTime());
         response.setBookedAt(representativeTicket.getBookedAt());
-        response.setStatus("PENDING_PAYMENT"); // Default status after booking
+        response.setStatus("PENDING_PAYMENT");
         response.setTotalPrice(totalPrice);
 
         List<BookingResponse.SeatInfo> seatInfos = allTickets.stream()
@@ -133,30 +160,23 @@ public class TicketServiceImpl implements TicketService {
         return response;
     }
 
-    // --- Other methods need to be implemented properly as well ---
-
     @Override
     public List<BookingResponse> getUserBookings() {
-        // This needs a proper implementation
         log.warn("getUserBookings is not fully implemented yet.");
         return new ArrayList<>();
     }
 
     @Override
     public BookingResponse getBookingDetails(Long ticketId) {
-        // This needs a proper implementation
         log.warn("getBookingDetails is not fully implemented yet.");
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new ApiException(ErrorCode.TICKET_NOT_FOUND));
-        // This mapping is simplified, might need to fetch all tickets of the same booking
         return mapToBookingResponse(ticket, List.of(ticket), ticket.getPrice());
-
     }
 
     @Override
     @Transactional
     public void cancelBooking(Long ticketId) {
-        // This needs a proper implementation
         log.warn("cancelBooking is not fully implemented yet.");
     }
 }

--- a/src/main/resources/db/redesign/V1__booking_schema_redesign.sql
+++ b/src/main/resources/db/redesign/V1__booking_schema_redesign.sql
@@ -1,0 +1,14 @@
+-- Booking schema redesign for concurrency-safe seat reservation
+-- NOTE: Adjust SQL syntax if your runtime database is not MySQL-compatible.
+
+ALTER TABLE Seats
+    ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE Tickets
+    ADD COLUMN IF NOT EXISTS booking_reference VARCHAR(64) NOT NULL DEFAULT 'legacy-booking';
+
+CREATE INDEX IF NOT EXISTS idx_tickets_showtime_cancelled
+    ON Tickets(showtime_id, is_cancelled);
+
+CREATE INDEX IF NOT EXISTS idx_tickets_booking_reference
+    ON Tickets(booking_reference);


### PR DESCRIPTION
## Summary
This PR redesigns the booking persistence flow and updates ticket booking logic to be concurrency-safe.

## What Changed
- Added DB-level shape improvements for booking:
  - `Tickets.booking_reference`
  - indexes for showtime/cancelled and booking_reference
  - optimistic version field in `Seat`
- Updated booking logic in `TicketServiceImpl`:
  - validate request early
  - lock selected seats using `PESSIMISTIC_WRITE`
  - check availability under lock to prevent race conditions
  - generate shared `bookingReference` for grouped seat booking
- Updated repositories:
  - `SeatRepository.findByShowtimeIdAndSeatNumberInForUpdate(...)`
  - `SeatRepository.findByShowtimeIdAndIsAvailableTrue(...)`
  - `TicketRepository` helper methods for booking queries
- Added SQL file for schema migration guidance:
  - `src/main/resources/db/redesign/V1__booking_schema_redesign.sql`

## Why
Current booking flow can suffer from concurrent double-booking when two requests reserve the same seat at the same time. This PR introduces transactional locking semantics and schema support to harden the flow.

## Notes
- Behavior is preserved for existing APIs.
- This work is tracked by the newly created DB redesign issue.